### PR TITLE
Use s3 library with recursive option

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ exports.connect = function (opts) {
 
     var list = client.listObjects(
       {s3Params: {Bucket: opts.bucket, Prefix: path, Delimiter: '/'},
-      recursive: params ? params.recursive : false});
+      recursive: params ? params.recursive : true});
 
     stream.readable = true
     

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "Get a file list from an Amazon S3 bucket.",
   "main": "index.js",
   "dependencies": {
-    "aws2js": "~0.8.3",
-    "xml-object-stream": "~0.2.0"
+    "s3": "^4.4.0"
   },
   "repository": "git@github.com:scottcorgan/bucket-list.git",
   "keywords": [


### PR DESCRIPTION
I recently found `bucket-zip` and this nice set of bucket utils!

`bucket-zip` has been very useful, but I needed the additional ability to both (a) zip folders with nested folders (via recursive listing) and (b) handle directories with 1000+ objects. This PR adds support for these options, and potentially others, at the `bucket-list` level via two changes:
- Use the `s3` library (https://www.npmjs.com/package/s3), which wraps the official `aws-sdk`, rather than the deprecated `aws2js`.
- Accept a `params` which for now just includes `recursive`. Could add other parameters supported by `s3` in the future.

I tried to otherwise keep the API exactly as is. This change should be coupled with two very minimal changes to `bucket-files` and `bucket-zip`, which I have PRs ready for -- just adding `params` as an argument to both.
